### PR TITLE
test tearDown complains about deprecated private service usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/security-bundle": "~3.4|~4.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "~1.4",
+        "doctrine/doctrine-bundle": "^1.6.12",
         "symfony/console": "~3.4|~4.0",
         "symfony/framework-bundle": "~3.4|~4.0",
         "symfony/phpunit-bridge": "~3.4|~4.0",


### PR DESCRIPTION
prefer-lowest tests should be fixed with https://github.com/doctrine/DoctrineBundle/commit/96a074a6202d6caf504fb728688f89bb76caf987 I hope