### PR TITLE
Document schema changes with DoctrineMigrationsBundle

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -92,9 +92,22 @@ system is supposed to use:
 After the connection is configured, you have to import the database structure
 running the following command:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console acl:init
+
+If you are using `DoctrineMigrationsBundle`_, the schema changes can be applied
+by diffing your current schema.
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:migration:diff
+
+This will create a new migration you can then apply.
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:migration:migrate
 
 Getting Started
 ---------------
@@ -243,4 +256,5 @@ added above:
 The user is now allowed to view, edit, delete, and un-delete objects.
 
 .. _`built-in security voters`: https://symfony.com/doc/current/security/voters.html
+.. _`DoctrineMigrationsBundle`: https://symfony.com/doc/master/bundles/DoctrineMigrationsBundle/index.html
 .. _`MongoDBAclBundle`: https://github.com/IamPersistent/MongoDBAclBundle


### PR DESCRIPTION
With DoctrineMigrationsBundle, the schema changes will be loaded transparently through a schema listener so that users can apply the schema changes for AclBundle by simply diffing the schema.