### PR TITLE
Fix SetAclCommand to get MaskBuilder from MaskBuilderRetrievalInterface

### DIFF
--- a/src/Command/SetAclCommand.php
+++ b/src/Command/SetAclCommand.php
@@ -20,8 +20,8 @@ use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException;
-use Symfony\Component\Security\Acl\Permission\MaskBuilder;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
+use Symfony\Component\Security\Acl\Permission\MaskBuilderRetrievalInterface;
 
 /**
  * Sets ACL for objects.
@@ -32,13 +32,17 @@ final class SetAclCommand extends Command
 {
     protected static $defaultName = 'acl:set';
 
+    /** @var MutableAclProviderInterface */
     private $provider;
+    /** @var MaskBuilderRetrievalInterface */
+    private $maskBuilderRetrieval;
 
-    public function __construct(MutableAclProviderInterface $provider)
+    public function __construct(MutableAclProviderInterface $provider, MaskBuilderRetrievalInterface $maskBuilderRetrieval)
     {
         parent::__construct();
 
         $this->provider = $provider;
+        $this->maskBuilderRetrieval = $maskBuilderRetrieval;
     }
 
     /**
@@ -73,8 +77,7 @@ EOF
             ->addArgument('arguments', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'A list of permissions and object identities (class name and ID separated by a column)')
             ->addOption('user', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A list of security identities')
             ->addOption('role', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A list of roles')
-            ->addOption('class-scope', null, InputOption::VALUE_NONE, 'Use class-scope entries')
-        ;
+            ->addOption('class-scope', null, InputOption::VALUE_NONE, 'Use class-scope entries');
     }
 
     /**
@@ -84,7 +87,7 @@ EOF
     {
         // Parse arguments
         $objectIdentities = array();
-        $maskBuilder = new MaskBuilder();
+        $maskBuilder = $this->maskBuilderRetrieval->getMaskBuilder();
         foreach ($input->getArgument('arguments') as $argument) {
             $data = explode(':', $argument, 2);
 

--- a/src/Resources/config/console.xml
+++ b/src/Resources/config/console.xml
@@ -15,6 +15,7 @@
 
         <service id="Symfony\Bundle\AclBundle\Command\SetAclCommand">
             <argument type="service" id="security.acl.provider" />
+            <argument type="service" id="security.acl.permission.map" />
             <tag name="console.command" command="acl:set" />
         </service>
     </services>

--- a/tests/Functional/SetAclCommandTest.php
+++ b/tests/Functional/SetAclCommandTest.php
@@ -41,7 +41,9 @@ class SetAclCommandTest extends FunctionalTestCase
         $role = 'ROLE_ADMIN';
 
         $application = $this->getApplication();
-        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('security.acl.provider')));
+        $application->add(new SetAclCommand(
+            self::$container->get('security.acl.provider'),
+            self::$container->get('security.acl.permission.map')));
 
         $setAclCommand = $application->find('acl:set');
         $setAclCommandTester = new CommandTester($setAclCommand);
@@ -83,7 +85,9 @@ class SetAclCommandTest extends FunctionalTestCase
         $role = 'ROLE_USER';
 
         $application = $this->getApplication();
-        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('security.acl.provider')));
+        $application->add(new SetAclCommand(
+            self::$container->get('security.acl.provider'),
+            self::$container->get('security.acl.permission.map')));
 
         $setAclCommand = $application->find('acl:set');
         $setAclCommandTester = new CommandTester($setAclCommand);

--- a/tests/Functional/app/config/framework.yml
+++ b/tests/Functional/app/config/framework.yml
@@ -3,3 +3,12 @@ framework:
 
 services:
     logger: { class: Psr\Log\NullLogger }
+    test.service_container:
+        class: Symfony\Bundle\FrameworkBundle\Test\TestContainer
+        public: true
+        arguments:
+            - '@kernel'
+            - 'test.private_services_locator'
+    test.private_services_locator:
+        class: Symfony\Component\DependencyInjection\ServiceLocator
+        public: true


### PR DESCRIPTION
SetAclCommand was instantiating MaskBuilder directly rather than retrieving it from MaskBuilderRetrievalInterface. This makes it impossible to use if you extended the MaskBuilder to add your custom masks.
This commit retrieves it from the MaskBuilderRetrievalInterface service.