### PR TITLE
Remove kernel name from tests

### DIFF
--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -41,18 +41,6 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        if (null === $this->name) {
-            $this->name = parent::getName().md5($this->rootConfig);
-        }
-
-        return $this->name;
-    }
-
     public function registerBundles()
     {
         if (!is_file($filename = $this->getRootDir().'/'.$this->testCase.'/bundles.php')) {


### PR DESCRIPTION
> The "Symfony\Component\HttpKernel\Kernel::getName()" method is deprecated since Symfony 4.2