### PR TITLE
Allowed PHP 8.0 in composer.json and enabled Travis builds on PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ matrix:
         - COMPOSER_FLAGS="--prefer-lowest"
 
     # Test latest php with LTS versions.
-    - php: 7.4
+    - php: 8.0
       env: SYMFONY_REQUIRE='^4.4'
 
     # Test the latest stable release
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0    
 
 before_install:
   - composer global require symfony/flex

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.9",
+        "php": ">=7.2.9",
         "ext-xml": "*",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.6.12|^2.0",
+        "doctrine/dbal": "~2.2",
         "symfony/console": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/phpunit-bridge": "^5.0",


### PR DESCRIPTION
Allowed PHP 8.0 in composer.json and enabled Travis builds on PHP 8.0.

Also, to make tests green, locked the doctrine/dbal package to ~2.2 (the same version is used in https://github.com/symfony/security-acl/blob/main/composer.json#L26) because the symfony/security-acl is not compatible with doctrine/dbal 3.0 yet.