### PR TITLE
Remove unnecessary method override

### DIFF
--- a/src/AclBundle.php
+++ b/src/AclBundle.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\AclBundle;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -19,8 +18,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class AclBundle extends Bundle
 {
-    public function registerCommands(Application $application)
-    {
-        // disable convention based registration as commands are registered as service
-    }
 }


### PR DESCRIPTION
Since the bundle requires Symfony 4.4 at a minimum, which doesn't have the convention-based command registration, this method override is no longer necessary.