### PR TITLE
Fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }


### PR DESCRIPTION
We have already released a 2.1 from master, so that branch does not reflect 2.0 anymore.