### PR TITLE
Make compatible with DBAL 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.6.12|^2.0",
-        "doctrine/dbal": "~2.2",
+        "doctrine/dbal": "^2.13.1|^3.1",
+        "doctrine/orm": "^2.7.3",
         "symfony/console": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/phpunit-bridge": "^5.0",
@@ -39,6 +40,9 @@
     },
     "autoload-dev": {
         "psr-4": { "Symfony\\Bundle\\AclBundle\\Tests\\": "tests/" }
+    },
+    "conflict": {
+        "doctrine/dbal": "<2.13.1|~3.0.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Command/InitAclCommand.php
+++ b/src/Command/InitAclCommand.php
@@ -73,7 +73,7 @@ EOF
         }
 
         foreach ($this->schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->exec($sql);
+            $this->connection->executeStatement($sql);
         }
 
         $output->writeln('ACL tables have been initialized successfully.');


### PR DESCRIPTION
The only change needed is updating the `acl:init` command to not use the deprecated API.