### PR TITLE
Allow symfony 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         strategy:
             matrix:
                 # Test the latest stable release
-                php: [7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0, 8.1]
                 deps: [stable]
-                symfony: ['^5.0']
+                symfony: ['^5.0', '^6.0']
                 include:
                     # Test lowest dependencies
                     - php: 7.2
@@ -29,6 +29,18 @@ jobs:
                     - php: 8.0
                       deps: stable
                       symfony: '^4.4'
+
+                    # Test latest php with LTS versions
+                    - php: 8.0
+                      deps: stable
+                      symfony: '^5.4'
+                exclude:
+                    - php: 7.2
+                      symfony: '^6.0'
+                    - php: 7.3
+                      symfony: '^6.0'
+                    - php: 7.4
+                      symfony: '^6.0'
 
         steps:
             - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
             - name: Configure Symfony version
               run: 'echo SYMFONY_REQUIRE="${{ matrix.symfony }}" >> $GITHUB_ENV'
 
+            - run: composer config minimum-stability dev
+              if: "${{ matrix.symfony == '^6.0' }}"
+
             - name: Composer install
               uses: 'ramsey/composer-install@v1'
               with:

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     "require": {
         "php": ">=7.2.9",
         "ext-xml": "*",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/dependency-injection": "^4.4|^5.3|^6.0",
+        "symfony/http-kernel": "^4.4|^5.3|^6.0",
         "symfony/security-acl": "^3.0",
-        "symfony/security-bundle": "^4.4|^5.0"
+        "symfony/security-bundle": "^4.4|^5.3|^6.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.6.12|^2.0",
         "doctrine/dbal": "^2.13.1|^3.1",
         "doctrine/orm": "^2.7.3",
         "symfony/console": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/yaml": "^4.4|^5.0"
+        "symfony/framework-bundle": "^4.4|^5.3|^6.0",
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/yaml": "^4.4|^5.3|^6.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "To use the default dbal configuration"

--- a/tests/DependencyInjection/Fixtures/php/cache_pool.php
+++ b/tests/DependencyInjection/Fixtures/php/cache_pool.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php', $container);
+$this->load('container1.php');
 
 $container->loadFromExtension('acl', [
     'cache' => [

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -13,15 +13,16 @@ namespace Symfony\Bundle\AclBundle\Tests\Functional;
 
 use Symfony\Bundle\AclBundle\Tests\Functional\app\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class FunctionalTestCase extends KernelTestCase
 {
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return AppKernel::class;
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         $class = self::getKernelClass();
 

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -41,7 +41,7 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         if (!is_file($filename = $this->getRootDir().'/'.$this->testCase.'/bundles.php')) {
             throw new \RuntimeException(sprintf('The bundles file "%s" does not exist.', $filename));
@@ -55,12 +55,12 @@ class AppKernel extends Kernel
         return __DIR__;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/logs';
     }
@@ -81,7 +81,7 @@ class AppKernel extends Kernel
         $this->__construct($a[0], $a[1], $a[2], $a[3]);
     }
 
-    protected function getKernelParameters()
+    protected function getKernelParameters(): array
     {
         $parameters = parent::getKernelParameters();
         $parameters['kernel.test_case'] = $this->testCase;


### PR DESCRIPTION
The `temp: ` commit needs to be reverted/removed when a new release of `symfony/security-acl` is released with symfony/security-acl#92