### PR TITLE
SF7 compatibility changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,15 @@ jobs:
                       deps: stable
                       symfony: '^4.4'
 
-                    # Test latest php/Symfony
+                    # Test Symfony 6
                     - php: 8.1
                       deps: stable
                       symfony: '^6.0'
+
+                    # Test latest php/Symfony
+                    - php: 8.2
+                      deps: stable
+                      symfony: '^7.0'
 
         steps:
             - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     "require": {
         "php": ">=7.2.9",
         "ext-xml": "*",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.0|^6.0|^7.0",
+        "symfony/http-kernel": "^4.4|^5.0|^6.0|^7.0",
         "symfony/security-acl": "^3.0",
-        "symfony/security-bundle": "^4.4|^5.0|^6.0"
+        "symfony/security-bundle": "^4.4|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.6.12|^2.0",
         "doctrine/dbal": "^2.13.1|^3.1",
         "doctrine/orm": "^2.7.3",
-        "symfony/console": "^4.4|^5.0|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/phpunit-bridge": "^5.0|^6.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0"
+        "symfony/console": "^4.4|^5.0|^6.0|^7.0",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0|^7.0",
+        "symfony/phpunit-bridge": "^5.0|^6.0|^7.0",
+        "symfony/yaml": "^4.4|^5.0|^6.0|^7.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "To use the default dbal configuration"

--- a/src/Command/InitAclCommand.php
+++ b/src/Command/InitAclCommand.php
@@ -41,7 +41,7 @@ final class InitAclCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Creates ACL tables in the database')
@@ -62,7 +62,7 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $this->schema->addToSchema($this->connection->getSchemaManager()->createSchema());

--- a/src/Command/SetAclCommand.php
+++ b/src/Command/SetAclCommand.php
@@ -44,7 +44,7 @@ final class SetAclCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Sets ACL for objects')
@@ -80,7 +80,7 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Parse arguments
         $objectIdentities = [];

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('acl');
         $rootNode = $builder->getRootNode();


### PR DESCRIPTION
Symfony 7 compatibility changes.
symfony/security-acl package still have some incompatibility issues, so a fix is also needed in that package